### PR TITLE
Update JuliaFormatter.jl to 0.22

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,6 @@ PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 
 [compat]
 JSON = "0.21"
-JuliaFormatter = "0.21"
+JuliaFormatter = "0.22"
 PackageCompiler = "1"
 julia = "1"


### PR DESCRIPTION
I've tested in my environment and it works. 0.22 has better support for YAS, trailing semicolon, and matrix format.